### PR TITLE
Add Docker support for reader Solid app

### DIFF
--- a/apps/reader-solid/Dockerfile
+++ b/apps/reader-solid/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+
+FROM node:22 AS builder
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps ./apps
+
+RUN pnpm install --frozen-lockfile
+
+RUN pnpm --filter @writer/reader-solid... build
+
+FROM node:22-slim AS runner
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/pnpm-lock.yaml ./
+COPY --from=builder /app/pnpm-workspace.yaml ./
+COPY --from=builder /app/apps ./apps
+COPY --from=builder /app/node_modules ./node_modules
+
+EXPOSE 3000
+
+CMD ["pnpm", "--filter", "@writer/reader-solid", "start"]

--- a/apps/reader-solid/src/lib/trpc.ts
+++ b/apps/reader-solid/src/lib/trpc.ts
@@ -5,16 +5,38 @@ import { isServer } from "solid-js/web";
 import type { AppRouter } from "@writer/server";
 import { getUserSessionQuery } from "./session";
 
+const processEnv =
+  (globalThis as unknown as {
+    process?: { env?: Record<string, string | undefined> };
+  }).process?.env ?? {};
+
+const internalTrpcBase =
+  processEnv.READER_TRPC_URL ?? "http://localhost:2022";
+
+const normalizeBaseUrl = (url: string) => url.replace(/\/$/, "");
+
+const resolveBrowserTrpcBase = () => {
+  if (typeof window === "undefined") {
+    return normalizeBaseUrl(internalTrpcBase);
+  }
+
+  if (window.location.host.includes("localhost")) {
+    return normalizeBaseUrl(internalTrpcBase);
+  }
+
+  return "https://writer.serial-experiments.com";
+};
+
+const buildTrpcUrl = (base: string) => `${normalizeBaseUrl(base)}/trpc`;
+
 // We'll need to properly type this with the actual AppRouter type
 // from the server, but for now we'll use any
 export const trpc = createTRPCClient<AppRouter>({
   links: [
     httpBatchLink({
       url: isServer
-        ? "http://localhost:2022/trpc"
-        : window.location.host.includes("localhost")
-          ? "http://localhost:2022/trpc"
-          : "https://writer.serial-experiments.com/trpc",
+        ? buildTrpcUrl(internalTrpcBase)
+        : buildTrpcUrl(resolveBrowserTrpcBase()),
       async headers() {
         "use server";
         const userSession = await getUserSessionQuery();

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,13 +15,21 @@ services:
       caddy: writer.serial-experiments.com
       caddy.reverse_proxy: "{{upstreams 2022}}"
   reader:
+    build:
+      context: .
+      dockerfile: apps/reader-solid/Dockerfile
     image: aeolun/writer-reader:latest
+    environment:
+      - READER_TRPC_URL=http://server:2022
+      - SESSION_SECRET=${READER_SESSION_SECRET}
+    expose:
+      - "3000"
     networks:
       - default
       - caddy
     labels:
       caddy: reader.serial-experiments.com
-      caddy.reverse_proxy: "{{upstreams 80}}"
+      caddy.reverse_proxy: "{{upstreams 3000}}"
   redis:
     image: redis:latest
 


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for the Solid reader that builds with pnpm and runs the built output
- read `READER_TRPC_URL` in the TRPC client so the Solid server can call the API inside Docker
- point the production compose file at the new image build, wiring the reverse proxy to port 3000 and session secret env var

## Testing
- `pnpm --filter @writer/reader-solid build` *(fails: "Title" is not exported by "@solidjs/start" during SSR build)*

------
https://chatgpt.com/codex/tasks/task_e_68d0aeae4e2883228dbe30b4a20ee5be